### PR TITLE
Fix random crash when gc is running and goroutine with hack is exiting

### DIFF
--- a/g/getg_amd64p32.s
+++ b/g/getg_amd64p32.s
@@ -1,4 +1,4 @@
 // Copyright 2018 Huan Du. All rights reserved.
 // Licensed under the MIT license that can be found in the LICENSE file.
 
-#include "info_amd64.s"
+#include "getg_amd64.s"

--- a/g/getg_arm64.s
+++ b/g/getg_arm64.s
@@ -1,0 +1,10 @@
+// Copyright 2018 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+TEXT ·getg(SB), NOSPLIT, $0-4
+    MOVW    g, R8
+    MOVW    R8, ret+0(FP)
+    RET

--- a/goexit.go
+++ b/goexit.go
@@ -44,12 +44,16 @@ func init() {
 		ch <- pc[sz-1]
 	}()
 	originalGoexitFn = <-ch
+
 }
 
 // Get hacked goexit pc.
 func init() {
+	entry := runtime.FuncForPC(originalGoexitFn).Entry()
+	pcQuantum := originalGoexitFn - entry
+
 	var hackedIf interface{} = hackedGoexit
-	hackedGoexitFn = *(*interfaceImpl)(unsafe.Pointer(&hackedIf)).funcPtr
+	hackedGoexitFn = *(*interfaceImpl)(unsafe.Pointer(&hackedIf)).funcPtr + pcQuantum
 
 	fnHacked := runtime.FuncForPC(hackedGoexitFn)
 	fnSymtab := (*_func)(unsafe.Pointer(fnHacked))
@@ -62,7 +66,9 @@ func init() {
 	mprotect(unsafe.Pointer(fnSymtab), funcSymbolSize, protectRead)
 }
 
-func hackedGoexit() {
+func hackedGoexit()
+
+func hackedGoexit1() {
 	resetAtExit()
 	runtime.Goexit()
 	panic("never return")

--- a/goexit_386.s
+++ b/goexit_386.s
@@ -1,0 +1,13 @@
+// Copyright 2018 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+// The hacked top-most function.
+// returns to goexit+PCQuantum.
+TEXT ·hackedGoexit(SB),NOSPLIT,$0-0
+	BYTE	$0x90	// NOP
+	CALL	·hackedGoexit1(SB)	// does not return
+	// traceback from hackedGoexit1 must hit code range of hackedGoexit.
+	BYTE	$0x90	// NOP

--- a/goexit_amd64.s
+++ b/goexit_amd64.s
@@ -1,0 +1,13 @@
+// Copyright 2018 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+// The hacked top-most function.
+// returns to goexit+PCQuantum.
+TEXT ·hackedGoexit(SB),NOSPLIT,$0-0
+	BYTE	$0x90	// NOP
+	CALL	·hackedGoexit1(SB)	// does not return
+	// traceback from hackedGoexit1 must hit code range of hackedGoexit.
+	BYTE	$0x90	// NOP

--- a/goexit_amd64p32.s
+++ b/goexit_amd64p32.s
@@ -1,0 +1,13 @@
+// Copyright 2018 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+// The hacked top-most function.
+// returns to goexit+PCQuantum.
+TEXT ·hackedGoexit(SB),NOSPLIT,$0-0
+	BYTE	$0x90	// NOP
+	CALL	·hackedGoexit1(SB)	// does not return
+	// traceback from hackedGoexit1 must hit code range of hackedGoexit.
+	BYTE	$0x90	// NOP

--- a/goexit_arm.s
+++ b/goexit_arm.s
@@ -1,0 +1,13 @@
+// Copyright 2018 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+// The hacked top-most function.
+// returns to goexit+PCQuantum.
+TEXT ·hackedGoexit(SB),NOSPLIT,$-4-0
+	MOVW	R0, R0	// NOP
+	BL	·hackedGoexit1(SB)	// does not return
+	// traceback from hackedGoexit1 must hit code range of hackedGoexit.
+	MOVW	R0, R0	// NOP

--- a/goexit_arm64.s
+++ b/goexit_arm64.s
@@ -1,0 +1,13 @@
+// Copyright 2018 Huan Du. All rights reserved.
+// Licensed under the MIT license that can be found in the LICENSE file.
+
+#include "go_asm.h"
+#include "textflag.h"
+
+// The hacked top-most function.
+// returns to goexit+PCQuantum.
+TEXT ·hackedGoexit(SB),NOSPLIT,$-8-0
+	MOVD	R0, R0	// NOP
+	BL	·hackedGoexit1(SB)	// does not return
+	// traceback from hackedGoexit1 must hit code range of hackedGoexit.
+	MOVD	R0, R0	// NOP

--- a/tls.go
+++ b/tls.go
@@ -158,8 +158,7 @@ func resetAtExit() {
 
 	tlsMu.Lock()
 	dm := tlsDataMap[gp]
-	funcs := make([]func(), 0, len(dm.atExitFuncs))
-	funcs = append(funcs, dm.atExitFuncs...)
+	funcs := dm.atExitFuncs
 	dm.atExitFuncs = nil
 	tlsMu.Unlock()
 


### PR DESCRIPTION
The `hackedGoexit` pc value must be a position inside the method so that gc can correctly find out the top of a frame when this method is executing. It's required to implement this method in asm with the same technic used by `runtime·goexit`.