### PR TITLE
Put the backwards compatibility code

### DIFF
--- a/tls.go
+++ b/tls.go
@@ -2,6 +2,8 @@
 // Licensed under the MIT license that can be found in the LICENSE file.
 
 // +build go1.7
+// It will be broken after go1.17, see: https://github.com/huandu/go-tls/issues/10
+// +build !go1.17
 
 // Package tls creates a TLS for a goroutine and release all resources at goroutine exit.
 package tls


### PR DESCRIPTION
Because #10 
It will be broken when **running** rather than compiled.
I think it will be dangerous if someone did not know this.

This break may be occurred  because golang uses the register to pass the param after go1.17, and some magic about go stack will be broken. 

This PR try to abandon some one use this library after go1.17

![image](https://user-images.githubusercontent.com/7782671/141942549-e6e42145-6568-4cbe-a65b-dc61b7f4d4cc.png)

